### PR TITLE
coll/ucc: make ucc default coll component

### DIFF
--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -45,9 +45,9 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
         .collm_init_query = mca_coll_ucc_init_query,
         .collm_comm_query = mca_coll_ucc_comm_query,
     },
-    10,               /* ucc_priority                */
+    100,               /* ucc_priority                */
     0,                 /* ucc_verbose                 */
-    0,                 /* ucc_enable                  */
+    1,                 /* ucc_enable                  */
     2,                 /* ucc_np                      */
     "",                /* cls                         */
     COLL_UCC_CTS_STR,  /* requested coll_types string */


### PR DESCRIPTION
Make UCC default collective component for OMPI.
Enables following collective: allgather, allgatherv, allreduce, alltoall, alltoallv, barrier, bcast, reduce