### PR TITLE
v4.1.x_hpcx: sync with v4.1.x from open-mpi repo/4.1.x

### DIFF
--- a/.github/workflows/ompi_nvidia.yaml
+++ b/.github/workflows/ompi_nvidia.yaml
@@ -2,7 +2,7 @@ name: ompi_NVIDIA CI
 on: [pull_request]
 jobs:
 
-  deployment:
+  nvidia_deployment:
     if: github.repository == 'open-mpi/ompi'
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
@@ -17,25 +17,25 @@ jobs:
         path: ompi_ci
     - name: Deployment infrastructure
       run: /start deploy
-  build:
-    needs: [deployment]
+  nvidia_build:
+    needs: [nvidia_deployment]
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Building OMPI,UCX and tests
       run: /start build
-  test:
-    needs: [deployment, build]
+  nvidia_test:
+    needs: [nvidia_deployment, nvidia_build]
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Running tests
       run: /start test
-  clean:
-# always() should be used to run "clean" even when the workflow was canceled 
+  nvidia_clean:
+# always() should be used to run "clean" even when the workflow was canceled
 #  ( in case of the right repository name)
 # The second condition doesn't work when the workflow was canceled
 
     if: always() && (github.repository == 'open-mpi/ompi')
-    needs: [deployment, build, test]
+    needs: [nvidia_deployment, nvidia_build, nvidia_test]
     runs-on: [self-hosted, linux, x64, nvidia]
     steps:
     - name: Cleaning

--- a/.nspect-allowlist.toml
+++ b/.nspect-allowlist.toml
@@ -1,0 +1,10 @@
+version = "1.0.0"
+
+# Allowlist for test private key in libevent library
+[[pulse-trufflehog.files]]
+file = "3rd-party/libevent-2.1.12-stable.tar.gz"
+
+  [[pulse-trufflehog.files.secrets]]
+  type = "PrivateKey"
+  values = [ "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAtK07Ili0dkJb79m/" ]
+

--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -245,7 +245,6 @@ Requires: %{modules_rpm_name}
 Requires: %{mpi_selector_rpm_name}
 %endif
 Requires: ucx
-Requires: hcoll
 
 %description
 Open MPI is an open source implementation of the Message Passing

--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -222,6 +222,7 @@
 
 Summary: A powerful implementation of MPI/SHMEM
 Name: %{?_name:%{_name}}%{!?_name:openmpi}
+Epoch: %{?epoch:%{epoch}}%{!?epoch:3}
 Version: $VERSION
 Release: 1%{?dist}
 License: BSD

--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -244,6 +244,8 @@ Requires: %{modules_rpm_name}
 %if %{use_mpi_selector}
 Requires: %{mpi_selector_rpm_name}
 %endif
+Requires: ucx
+Requires: hcoll
 
 %description
 Open MPI is an open source implementation of the Message Passing

--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -146,10 +146,6 @@
 # type: bool (0/1)
 %{!?allow_fortify_source: %define allow_fortify_source 1}
 
-# Select md5 packing algorithm, that src.rpm created on one distro can be read on another.
-%global _binary_filedigest_algorithm 1
-%global _source_filedigest_algorithm 1
-
 #############################################################################
 #
 # Configuration Logic

--- a/contrib/dist/mofed/debian/control.in
+++ b/contrib/dist/mofed/debian/control.in
@@ -5,7 +5,7 @@ Homepage: http://www.open-mpi.org/
 Maintainer:  http://www.open-mpi.org
 
 Package: openmpi
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucx, hcoll
 Architecture: all
 Description: Open MPI
  Open MPI is a project combining technologies and resources from

--- a/contrib/dist/mofed/debian/control.in
+++ b/contrib/dist/mofed/debian/control.in
@@ -5,7 +5,7 @@ Homepage: http://www.open-mpi.org/
 Maintainer:  http://www.open-mpi.org
 
 Package: openmpi
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucx, hcoll
+Depends: ${shlibs:Depends}, ${misc:Depends}, ucx
 Architecture: all
 Description: Open MPI
  Open MPI is a project combining technologies and resources from

--- a/ompi/mca/coll/ucc/coll_ucc_component.c
+++ b/ompi/mca/coll/ucc/coll_ucc_component.c
@@ -46,9 +46,9 @@ mca_coll_ucc_component_t mca_coll_ucc_component = {
         .collm_init_query = mca_coll_ucc_init_query,
         .collm_comm_query = mca_coll_ucc_comm_query,
     },
-    10,               /* ucc_priority                */
+    100,               /* ucc_priority                */
     0,                 /* ucc_verbose                 */
-    0,                 /* ucc_enable                  */
+    1,                 /* ucc_enable                  */
     2,                 /* ucc_np                      */
     "",                /* cls                         */
     COLL_UCC_CTS_STR,  /* requested coll_types string */

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -194,9 +194,9 @@ static ucc_status_t oob_allgather_test(void *req)
         tmpsend = (char*)oob_req->rbuf + (ptrdiff_t)senddatafrom * (ptrdiff_t)msglen;
         rc = MCA_PML_CALL(isend(tmpsend, msglen, MPI_BYTE, sendto, MCA_COLL_BASE_TAG_UCC,
                            MCA_PML_BASE_SEND_STANDARD, comm, &oob_req->reqs[0]));
-	if (OMPI_SUCCESS != rc) {
+        if (OMPI_SUCCESS != rc) {
             return UCC_ERR_NO_MESSAGE;
-	}
+        }
         rc = MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
                            MCA_COLL_BASE_TAG_UCC, comm, &oob_req->reqs[1]));
 	if (OMPI_SUCCESS != rc) {

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -199,9 +199,9 @@ static ucc_status_t oob_allgather_test(void *req)
         }
         rc = MCA_PML_CALL(irecv(tmprecv, msglen, MPI_BYTE, recvfrom,
                            MCA_COLL_BASE_TAG_UCC, comm, &oob_req->reqs[1]));
-	if (OMPI_SUCCESS != rc) {
+        if (OMPI_SUCCESS != rc) {
             return UCC_ERR_NO_MESSAGE;
-	}
+        }
     }
     probe = 0;
     do {

--- a/opal/mca/pmix/pmix3x/pmix/contrib/pmix.spec
+++ b/opal/mca/pmix/pmix3x/pmix/contrib/pmix.spec
@@ -126,10 +126,6 @@
 # type: bool (0/1)
 %{!?allow_fortify_source: %define allow_fortify_source 1}
 
-# Select md5 packing algorithm, that src.rpm created on one distro can be read on another.
-%global _binary_filedigest_algorithm 1
-%global _source_filedigest_algorithm 1
-
 #############################################################################
 #
 # Configuration Logic


### PR DESCRIPTION
it'll be cleaner if you just resync v4.1.x with upstream, and then apply patches and force push
The reason I'm doing this is that I want to create a PR to disable HCOLL by default but I want to do it on a clean _hpcx branch synced with upstream since we have segfault fixes there.