### PR TITLE
security: pin requirements versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0
-recommonmark
-docutils
-sphinx-rtd-theme
+sphinx==7.2.6
+recommonmark==0.7.1
+docutils==0.20.1
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
### Pin specific versions for documentation build dependencies to address nSpect "Packages without version" alert.

## Details
- **nSpect ID:** NSPECT-MNND-LO9V
- **Alert:** Packages without version

The following packages were flagged as not having pinned versions:
- Docutils
- sphinx_rtd_theme  
- recommonmark
- Sphinx

## Changes
Updated `docs/requirements.txt` with tested, compatible versions:

| Package | Before | After |
|---------|--------|-------|
| sphinx | >=4.2.0 | ==7.2.6 |
| recommonmark | (none) | ==0.7.1 |
| docutils | (none) | ==0.20.1 |
| sphinx-rtd-theme | (none) | ==2.0.0 |


## Approval
Approved by @tomislavj in mail need github formal approval 