### PR TITLE
docs: downgrade Python doc dependencies to support older Python versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==7.2.6
+sphinx==5.3.0
 recommonmark==0.7.1
-docutils==0.20.1
+docutils==0.18.1
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
Adjust documentation build requirements to ensure compatibility with Python 3.6+ environments used across HPCX build matrix.

Changes:
- sphinx: 7.2.6 -> 5.3.0 (requires Python >=3.6 instead of >=3.9)
- docutils: 0.20.1 -> 0.18.1 (minimum version compatible with all tested OS)

Rationale:
The previous pinned versions (sphinx==7.2.6, docutils==0.20.1) required Python 3.9+, causing build failures on systems with Python 3.6-3.8. Sphinx 5.3.0 and docutils 0.18.1 maintain nSpect compliance with exact version pinning while supporting the full range of Python versions in the HPCX build infrastructure.

Tested successfully across: RHEL 7-10, CentOS 8-10, SLES 15.4-15.6, Ubuntu 22.04/24.04, Debian 12/13, Kylin 10.

Related: nSpect alert NSPECT-MNND-LO9V