### PR TITLE
docs: pin Python doc dependencies to avoid high Python version requir…

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0
-recommonmark
-docutils
-sphinx-rtd-theme
+sphinx==5.3.0
+recommonmark==0.7.1
+docutils==0.18.1
+sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
…ements

Pin documentation build requirements to specific tested versions that support Python 3.6+ environments used across HPCX build matrix.

Changes:
- sphinx: >=4.2.0 -> ==5.3.0 (prevents upgrade to 7.x which requires Python >=3.9)
- recommonmark: (unpinned) -> ==0.7.1
- docutils: (unpinned) -> ==0.18.1
- sphinx-rtd-theme: (unpinned) -> ==2.0.0

Rationale:
The previous flexible versions (sphinx>=4.2.0) allowed pip to install sphinx 7.x which requires Python 3.9+, causing build failures on systems with Python 3.6-3.8. Pinning to sphinx==5.3.0 ensures compatibility with the full range of Python versions while also satisfying nSpect compliance requirements for exact version pinning.

Tested successfully across: RHEL 7-10, CentOS 8-10, SLES 15.4-15.6, Ubuntu 22.04/24.04, Debian 12/13, Kylin 10.

Related: nSpect alert NSPECT-MNND-LO9V