### PR TITLE
prrte: add autogen patch mechanism and fix NULL topology crashes

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -1516,6 +1516,43 @@ Perhaps you forgot to \"git clone --recursive ...\", or you need to
 
 #---------------------------------------------------------------------------
 
+# Apply local patches to 3rd-party submodules (if any exist in patches/)
+++$step;
+verbose "\n$step. Applying local patches to 3rd-party submodules\n\n";
+
+my $patches_dir = "contrib/patches";
+if (-d $patches_dir) {
+    opendir(my $pdh, $patches_dir) || my_die "Can't open $patches_dir";
+    my @subdirs_to_patch = sort grep { !/^\./ && -d "$patches_dir/$_" } readdir($pdh);
+    closedir($pdh);
+
+    foreach my $submod (@subdirs_to_patch) {
+        my $submod_dir = "3rd-party/$submod";
+        next unless -d $submod_dir;
+
+        my @patchfiles = sort glob("$patches_dir/$submod/*.patch");
+        next unless @patchfiles;
+
+        verbose "=== Patching $submod_dir\n";
+        my $start = Cwd::cwd();
+        chdir($submod_dir) || my_die "Can't chdir to $submod_dir";
+        foreach my $pfile (@patchfiles) {
+            my $abs_pfile = "$start/$pfile";
+            verbose "--- Applying $pfile\n";
+            # -N: ignore already-applied patches; -p1: strip one path component
+            system("$patch_prog -N -p1 < $abs_pfile > /dev/null 2>&1");
+            if ($? != 0) {
+                verbose "    (already applied or failed - continuing)\n";
+            }
+        }
+        chdir($start);
+    }
+} else {
+    verbose "=== No patches/ directory found, skipping\n";
+}
+
+#---------------------------------------------------------------------------
+
 # Save the platform file in the m4
 $m4 .= "dnl Platform file\n";
 

--- a/contrib/patches/prrte/0001-plm-rmaps-fix-null-topology-race-in-daemon-callbacks.patch
+++ b/contrib/patches/prrte/0001-plm-rmaps-fix-null-topology-race-in-daemon-callbacks.patch
@@ -1,0 +1,80 @@
+diff --git a/src/mca/plm/base/plm_base_launch_support.c b/src/mca/plm/base/plm_base_launch_support.c
+index 4c27663fa1..60ace9062b 100644
+--- a/src/mca/plm/base/plm_base_launch_support.c
++++ b/src/mca/plm/base/plm_base_launch_support.c
+@@ -1344,7 +1344,9 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
+     }
+ 
+     // setup the topology's summary
+-    prte_hwloc_base_setup_summary(topo);
++    if (NULL != topo) {
++        prte_hwloc_base_setup_summary(topo);
++    }
+ 
+ 
+ CLEANUP:
+@@ -1704,8 +1706,10 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
+             t->topo = topo;
+             t->index = pmix_pointer_array_add(prte_node_topologies, t);
+             daemon->node->topology = t;
+-            daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
+-            prte_hwloc_base_setup_summary(t->topo);
++            if (NULL != t->topo) {
++                daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
++                prte_hwloc_base_setup_summary(t->topo);
++            }
+             // cannot have cached daemons
+             free(nodename);
+             nodename = NULL;
+@@ -1746,9 +1750,12 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
+                 /* update the node's available processors */
+                 if (NULL != daemon->node->available) {
+                     hwloc_bitmap_free(daemon->node->available);
++                    daemon->node->available = NULL;
++                }
++                if (NULL != t->topo) {
++                    daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
++                    prte_hwloc_base_setup_summary(t->topo);
+                 }
+-                daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
+-                prte_hwloc_base_setup_summary(t->topo);
+                 break;
+             }
+         }
+@@ -1789,7 +1796,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
+                             goto CLEANUP;
+                         }
+                         dptr->node->topology = t;
+-                        if (NULL == dptr->node->available) {
++                        if (NULL == dptr->node->available && NULL != t->topo) {
+                             dptr->node->available = prte_hwloc_base_filter_cpus(t->topo);
+                             prte_hwloc_base_setup_summary(t->topo);
+                         }
+diff --git a/src/mca/rmaps/base/rmaps_base_support_fns.c b/src/mca/rmaps/base/rmaps_base_support_fns.c
+index b94d6aea15..439c51078a 100644
+--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
++++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
+@@ -401,6 +401,11 @@ complete:
+                 PMIX_RELEASE(node);
+                 continue;
+             }
++            /* node->available may be NULL if topology arrived after the daemon
++             * callback already ran - compute it now from the known topology */
++            if (NULL == node->available) {
++                node->available = prte_hwloc_base_filter_cpus(node->topology->topo);
++            }
+             /* cache the available CPUs for later */
+             hwloc_bitmap_copy(node->jobcache, node->available);
+         }
+@@ -417,6 +422,11 @@ complete:
+                 PMIX_RELEASE(node);
+                 continue;
+             }
++            /* node->available may be NULL if topology arrived after the daemon
++             * callback already ran - compute it now from the known topology */
++            if (NULL == node->available) {
++                node->available = prte_hwloc_base_filter_cpus(node->topology->topo);
++            }
+             /* if the hnp was not allocated, or flagged not to be used,
+              * then remove it here */
+             if (!prte_hnp_is_allocated ||

--- a/contrib/patches/prrte/0002-plm-slurm-forward-PRTE_PREFIX-for-LD_LIBRARY_PATH.patch
+++ b/contrib/patches/prrte/0002-plm-slurm-forward-PRTE_PREFIX-for-LD_LIBRARY_PATH.patch
@@ -1,0 +1,99 @@
+diff --git a/src/mca/plm/slurm/plm_slurm_module.c b/src/mca/plm/slurm/plm_slurm_module.c
+index 7954ad230f..5475fa0d21 100644
+--- a/src/mca/plm/slurm/plm_slurm_module.c
++++ b/src/mca/plm/slurm/plm_slurm_module.c
+@@ -561,7 +561,7 @@ static int plm_slurm_start_proc(int argc, char **argv,
+     int fd;
+     int srun_pid;
+     int n;
+-    char **tmp = NULL, *p;
++    char **tmp = NULL, *p, *saved_prte_prefix = NULL;
+     char *exec_argv = pmix_path_findv(argv[0], 0, environ, NULL);
+     prte_proc_t *dummy;
+     char *oldenv, *newenv;
+@@ -597,6 +597,14 @@ static int plm_slurm_start_proc(int argc, char **argv,
+     if (0 == srun_pid) { /* child */
+         char *bin_base = NULL, *lib_base = NULL;
+ 
++        /* Save PRTE_PREFIX before we purge PRTE_* from the environment.
++         * We will use it below to set PATH/LD_LIBRARY_PATH for prted
++         * if --prefix was not given on the mpirun command line. */
++        p = getenv("PRTE_PREFIX");
++        if (NULL != p) {
++            saved_prte_prefix = strdup(p);
++        }
++
+         /* Slurm forwards the entire environment, which we
+          * REALLY don't want them to do as it might contain
+          * envars pertaining to tool connections. So purge
+@@ -659,6 +667,39 @@ static int plm_slurm_start_proc(int argc, char **argv,
+             PMIX_SETENV_COMPAT("PRTE_PREFIX", prefix, true, &environ);
+         }
+ 
++        /* Fallback: if --prefix was not given but PRTE_PREFIX was in the
++         * environment, use it to configure PATH and LD_LIBRARY_PATH for
++         * prted on the compute nodes.  Without this, prted may load the
++         * wrong hwloc and fail to report a valid topology. */
++        if (NULL == prefix && NULL != saved_prte_prefix) {
++            /* Reset PATH */
++            oldenv = getenv("PATH");
++            if (NULL != oldenv) {
++                pmix_asprintf(&newenv, "%s/%s:%s", saved_prte_prefix, bin_base, oldenv);
++            } else {
++                pmix_asprintf(&newenv, "%s/%s", saved_prte_prefix, bin_base);
++            }
++            PMIX_SETENV_COMPAT("PATH", newenv, true, &environ);
++            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
++                                 "%s plm:slurm: set PATH from PRTE_PREFIX: %s",
++                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
++            free(newenv);
++            /* Reset LD_LIBRARY_PATH */
++            oldenv = getenv("LD_LIBRARY_PATH");
++            if (NULL != oldenv) {
++                pmix_asprintf(&newenv, "%s/%s:%s", saved_prte_prefix, lib_base, oldenv);
++            } else {
++                pmix_asprintf(&newenv, "%s/%s", saved_prte_prefix, lib_base);
++            }
++            PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &environ);
++            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
++                                 "%s plm:slurm: set LD_LIBRARY_PATH from PRTE_PREFIX: %s",
++                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
++            free(newenv);
++            /* re-export PRTE_PREFIX so srun propagates it to prted */
++            PMIX_SETENV_COMPAT("PRTE_PREFIX", saved_prte_prefix, true, &environ);
++        }
++
+         /* for pmix_prefix, we only have to modify the library path.
+          * NOTE: obviously, we cannot know the lib_base used for the
+          * PMIx library. All we can do is hope they used the same one
+diff --git a/src/prted/prte_app_parse.c b/src/prted/prte_app_parse.c
+index f3724841fc..345aa7fdc2 100644
+--- a/src/prted/prte_app_parse.c
++++ b/src/prted/prte_app_parse.c
+@@ -297,6 +297,13 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
+             iptr = PMIX_NEW(prte_info_item_t);
+             PMIX_INFO_LOAD(&iptr->info, "PRTE_PREFIX", opt->values[0], PMIX_STRING);
+             pmix_list_append(jobdata, &iptr->super);
++        } else if (NULL != (param = getenv("PRTE_PREFIX"))) {
++            /* --prefix was not given on the cmd line, but PRTE_PREFIX was set
++             * in the environment (e.g., by module load). Use it for daemon launch
++             * so the PLM can correctly set LD_LIBRARY_PATH on remote nodes. */
++            iptr = PMIX_NEW(prte_info_item_t);
++            PMIX_INFO_LOAD(&iptr->info, "PRTE_PREFIX", param, PMIX_STRING);
++            pmix_list_append(jobdata, &iptr->super);
+         }
+ 
+         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_PMIX_PREFIX);
+@@ -319,6 +326,12 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
+             iptr = PMIX_NEW(prte_info_item_t);
+             PMIX_INFO_LOAD(&iptr->info, PMIX_PREFIX, opt->values[0], PMIX_STRING);
+             pmix_list_append(jobdata, &iptr->super);
++        } else if (NULL != (param = getenv("PMIX_PREFIX"))) {
++            /* --pmix-prefix was not given on the cmd line, but PMIX_PREFIX was set
++             * in the environment (e.g., by module load). Forward it for daemon launch. */
++            iptr = PMIX_NEW(prte_info_item_t);
++            PMIX_INFO_LOAD(&iptr->info, PMIX_PREFIX, param, PMIX_STRING);
++            pmix_list_append(jobdata, &iptr->super);
+         }
+     }
+ 


### PR DESCRIPTION
Add infrastructure in autogen.pl to automatically apply patches from contrib/patches/<submodule>/ to 3rd-party submodules at autogen time, and add two patches to fix intermittent mpirun segfaults when running across multiple SLURM nodes with UCC+SHARP collectives.

Two distinct root causes were identified and fixed:

1. NULL topology race in daemon callbacks (0001-plm-rmaps-...patch)

   prted daemons can call back with a NULL topology (e.g. when hwloc fails to load the correct shared library on compute nodes). Several code paths in prte_plm_base_daemon_topology, daemon_callback, and prte_rmaps_base_get_target_nodes did not guard against this:

   - Guard prte_hwloc_base_setup_summary(topo) in daemon_topology
   - Guard filter_cpus/setup_summary in the new-topology branch of daemon_callback when t->topo is NULL
   - In the found=true branch: set node->available=NULL after hwloc_bitmap_free to prevent a dangling pointer, then guard filter_cpus/setup_summary when t->topo is NULL
   - Add NULL != t->topo to the cached-daemons branch condition
   - Lazily compute node->available in the mapper (rmaps) when it is still NULL at mapping time but topology is already known, covering both the TOOL and regular mapping paths before hwloc_bitmap_copy

2. Wrong hwloc loaded by prted due to missing LD_LIBRARY_PATH (0002-...)

   SLURM's plm module explicitly purges all PRTE_*/PMIX_* vars from the srun child environment and only sets LD_LIBRARY_PATH when --prefix is given on the mpirun command line. When launched via a module (e.g. HPC-X), PRTE_PREFIX is set in the environment but --prefix is not passed, so prted loads the system hwloc instead of the HPC-X one and reports a NULL topology:

   - In prte_app_parse, forward PRTE_PREFIX and PMIX_PREFIX from the environment into the job info when --prefix/--pmix-prefix are not given on the command line
   - In plm_slurm_start_proc, save PRTE_PREFIX before the env purge and use it as a fallback to set PATH and LD_LIBRARY_PATH for prted on compute nodes when --prefix was not provided