### PR TITLE
v5.0.x_hpcx: comm change teardown ordering in MPI_Finalize

### DIFF
--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -320,6 +320,48 @@ static int ompi_comm_finalize (void)
     /* disconnect all dynamic communicators */
     ompi_dpm_dyn_finalize();
 
+    /* Release any user-created communicators (cid >= 3; cids 0-2 are
+     * MPI_COMM_NULL, MPI_COMM_WORLD, and MPI_COMM_SELF) not freed by the
+     * application before MPI_Finalize.  This must happen before
+     * OBJ_DESTRUCT(&ompi_mpi_comm_world) below because MCA coll components
+     * attached to these communicators may rely on MPI_COMM_WORLD being alive
+     * during their teardown (e.g. to release collective library resources that
+     * were set up with OOB support). */
+    max = ompi_comm_get_num_communicators();
+    for ( i=3; i<max; i++ ) {
+        comm = ompi_comm_lookup(i);
+        if ( NULL != comm ) {
+            /* Communicator has not been freed before finalize */
+            opal_output_verbose(10, ompi_comm_output,
+                                "ompi_comm_finalize: releasing comm %p name \"%s\" size %d cid %d refcnt %d",
+                                (void *)comm, comm->c_name, ompi_comm_size(comm),
+                                comm->c_index,
+                                ((opal_object_t *)comm)->obj_reference_count);
+            OBJ_RELEASE(comm);
+            comm = ompi_comm_lookup(i);
+            if ( NULL != comm ) {
+                /* Still here ? */
+                if ( !OMPI_COMM_IS_EXTRA_RETAIN(comm)) {
+
+                    /* For communicator that have been marked as "extra retain", we do not further
+                     * enforce to decrease the reference counter once more. These "extra retain"
+                     * communicators created e.g. by the hierarch or inter module did increase
+                     * the reference count by one more than other communicators, on order to
+                     * allow for deallocation with the parent communicator. Note, that
+                     * this only occurs if the cid of the local_comm is lower than of its
+                     * parent communicator. Read the comment in comm_activate for
+                     * a full explanation.
+                     */
+                    if ( ompi_debug_show_handle_leaks && !(OMPI_COMM_IS_FREED(comm)) ){
+                        opal_output(0,"WARNING: MPI_Comm still allocated in MPI_Finalize\n");
+                        ompi_comm_dump ( comm);
+                        OBJ_RELEASE(comm);
+                    }
+                }
+            }
+        }
+    }
+
     if (ompi_comm_intrinsic_init) {
         /* tear down MPI-3 predefined communicators (not initialized unless using MPI_Init) */
         OBJ_DESTRUCT( &ompi_mpi_comm_self );
@@ -363,37 +405,6 @@ static int ompi_comm_finalize (void)
 
     /* Shut down MPI_COMM_NULL */
     OBJ_DESTRUCT( &ompi_mpi_comm_null );
-
-    /* Check whether we have some communicators left */
-    max = ompi_comm_get_num_communicators();
-    for ( i=3; i<max; i++ ) {
-        comm = ompi_comm_lookup(i);
-        if ( NULL != comm ) {
-            /* Communicator has not been freed before finalize */
-            OBJ_RELEASE(comm);
-            comm = ompi_comm_lookup(i);
-            if ( NULL != comm ) {
-                /* Still here ? */
-                if ( !OMPI_COMM_IS_EXTRA_RETAIN(comm)) {
-
-                    /* For communicator that have been marked as "extra retain", we do not further
-                     * enforce to decrease the reference counter once more. These "extra retain"
-                     * communicators created e.g. by the hierarch or inter module did increase
-                     * the reference count by one more than other communicators, on order to
-                     * allow for deallocation with the parent communicator. Note, that
-                     * this only occurs if the cid of the local_comm is lower than of its
-                     * parent communicator. Read the comment in comm_activate for
-                     * a full explanation.
-                     */
-                    if ( ompi_debug_show_handle_leaks && !(OMPI_COMM_IS_FREED(comm)) ){
-                        opal_output(0,"WARNING: MPI_Comm still allocated in MPI_Finalize\n");
-                        ompi_comm_dump ( comm);
-                        OBJ_RELEASE(comm);
-                    }
-                }
-            }
-        }
-    }
 
     OBJ_DESTRUCT (&ompi_mpi_communicators);
     OBJ_DESTRUCT (&ompi_comm_hash);

--- a/ompi/mca/coll/ucc/coll_ucc_module.c
+++ b/ompi/mca/coll/ucc/coll_ucc_module.c
@@ -124,9 +124,9 @@ static void mca_coll_ucc_module_destruct(mca_coll_ucc_module_t *ucc_module)
         }
     }
     /* ucc_context_destroy needs OOB via MPI_COMM_WORLD; call it while
-       COMM_WORLD is still alive (module destructor fires before c_local_group
-       is released in ompi_comm_destruct). mca_coll_ucc_close() will call
-       mca_coll_ucc_finalize_ctx() as a no-op safety net if already done. */
+     * COMM_WORLD is still alive. ompi_comm_finalize() releases leaked user
+     * communicators (cid >= 3) before OBJ_DESTRUCT(&ompi_mpi_comm_world),
+     * so all UCC teams are destroyed before the context. */
     if (ucc_module->comm == &ompi_mpi_comm_world.comm) {
         mca_coll_ucc_finalize_ctx();
     }


### PR DESCRIPTION
ompi_comm_finalize() was destroying MPI_COMM_WORLD before releasing user communicators (cid >= 3), causing MCA coll modules attached to those communicators to be destructed after MPI_COMM_WORLD was gone. Collective components that rely on MPI_COMM_WORLD being alive during teardown (e.g. for OOB-backed resource release) would therefore encounter use-after-free or null-context errors.

Fix: move the cid>=3 cleanup loop in ompi_comm_finalize() to execute before OBJ_DESTRUCT(&ompi_mpi_comm_world), ensuring all MCA coll modules can tear down cleanly while MPI_COMM_WORLD is still alive.

The ordering change is safe for all communicator types. Intra/sub-communicators cleaned up by cid>=loop, no change in behavior.

Inter-communicators (MPI_Intercomm_create) also have cid>=3 and are handled identically the loop just calls OBJ_RELEASE, same as before.

MPI_COMM_SELF (cid=2): not touched by the loop,
still destroyed in the if (ompi_comm_intrinsic_init) block.

ompi_mpi_comm_parent, ompi_dpm_dyn_finalize() runs at line 321, before loop. It disconnects and removes dynamic communicators from the table. After it runs, ompi_comm_lookup(i) for the parent's cid returns NULL, so the loop skips it.
The if (ompi_mpi_comm_parent != &ompi_mpi_comm_null.comm) block then handles it (or is skipped if dyn_finalize already set it back to null_comm). Critically, this relative ordering (dyn_finalize cid>=3 loop parent block) is the same as in the original code we only moved the loop relative to the intrinsic block.