### PR TITLE
ompi: install OpenMPI under /usr/mpi/gcc/openmpi-VERSION/ by default (SW#5008199, SW#5009387, SW#5010922)

### DIFF
--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -53,6 +53,33 @@
 # type: bool (0/1)
 %{!?install_in_opt: %define install_in_opt 0}
 
+# Mellanox/HPC-X fork: install OpenMPI under
+# /usr/mpi/gcc/<name>-<version>/ -- the long-standing MLNX_OFED / DOCA
+# packaging convention.  DOCA 3.3.0 (openmpi 4.1.9a1) shipped at
+# /usr/mpi/gcc/openmpi-4.1.9a1/, which kept all bundled libraries in a
+# unique versioned subdir and never collided with system packages.
+#
+# Why the prefix change is required: OMPI 5.x bundles openpmix and
+# prrte and, with the upstream default --prefix=/usr, drops
+# libpmix.so.2 and libprrte.so.3 into /usr/lib64/ plus help texts
+# under /usr/share/{pmix,prte}/.  Those collide with the system pmix
+# and prrte-libs packages on RHEL 10 / ctyunos / SLES (SW#5008199,
+# SW#5010922).  Moving --prefix to /usr/mpi/gcc/openmpi-<ver>/ keeps
+# the bundled libs in a versioned subdir and removes the collision.
+#
+# The Ubuntu 24.04 libevent-dev / evdns.h collision (SW#5009387) is a
+# separate symptom of the same upstream --prefix=/usr default, but it
+# only manifests when libevent is bundled (--with-libevent=internal).
+# With all_external_3rd_party=1 (this spec's default) libevent is
+# never bundled, so SW#5009387 is fixed independently of mofed_prefix.
+#
+# install_in_opt takes priority if also set (=> /opt/<name>/<version>).
+# Set mofed_prefix=0 (and install_in_opt=0) to fall back to the
+# upstream default of --prefix=/usr -- but that path causes the
+# pmix/prrte file collisions described above.
+# type: bool (0/1)
+%{!?mofed_prefix: %define mofed_prefix 1}
+
 # This specfile expects to find all required 3rd party packages
 # (Libevent, Hwloc, PMIx, PRRTE) externally, and will not use the
 # internal/embedded copies of these packages.  This behavior is
@@ -68,8 +95,13 @@
 
 # Define this if you want this RPM to install environment setup
 # shell scripts.
+# Mellanox/HPC-X fork: default flipped from upstream 0 -> 1, because
+# with mofed_prefix=1 (this fork's default) the OMPI binaries live
+# under /usr/mpi/gcc/openmpi-<version>/bin/ which is not on $PATH by
+# default; mpivars.{sh,csh} let users `source` them to set up the
+# environment.  Still overridable via rpmbuild --define.
 # type: bool (0/1)
-%{!?install_shell_scripts: %define install_shell_scripts 0}
+%{!?install_shell_scripts: %define install_shell_scripts 1}
 # type: string (root path to install shell scripts)
 %{!?shell_scripts_path: %define shell_scripts_path %{_bindir}}
 # type: string (base name of the shell scripts)
@@ -190,6 +222,22 @@
 # where they want it to go -- the modulefile is a bit different in
 # that the user may want it outside of /opt).
 %{!?modulefile_path: %define modulefile_path /opt/%{name}/%{version}/share/openmpi/modulefiles}
+%endif
+
+# Mellanox/HPC-X fork: when mofed_prefix=1 (the default in this fork)
+# and install_in_opt is not also set, install everything under
+# /usr/mpi/gcc/<name>-<version>/ (the MLNX_OFED / DOCA convention).
+%if %{mofed_prefix}
+%if !%{install_in_opt}
+%define _prefix /usr/mpi/gcc/%{name}-%{version}
+%define _sysconfdir %{_prefix}/etc
+%define _libdir %{_prefix}/lib
+%define _includedir %{_prefix}/include
+%define _mandir %{_prefix}/share/man
+%define _pkgdatadir %{_prefix}/share/openmpi
+%define _defaultdocdir %{_prefix}/share/doc
+%{!?modulefile_path: %define modulefile_path %{_prefix}/share/openmpi/modulefiles}
+%endif
 %endif
 
 %if %{all_external_3rd_party}

--- a/contrib/dist/mofed/debian/control.in
+++ b/contrib/dist/mofed/debian/control.in
@@ -3,6 +3,7 @@ Section: net
 Priority: extra
 Homepage: https://www.open-mpi.org/
 Maintainer:  https://www.open-mpi.org
+Build-Depends: debhelper (>= 8), libevent-dev, libhwloc-dev
 
 Package: openmpi
 Depends: ${shlibs:Depends}, ${misc:Depends}, ucx

--- a/contrib/dist/mofed/debian/rules.in
+++ b/contrib/dist/mofed/debian/rules.in
@@ -5,13 +5,41 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
+# Install everything under /usr/mpi/gcc/openmpi-<upstream-version>/
+# (the MLNX_OFED / DOCA packaging convention -- DOCA 3.3.0 openmpi 4.1.x
+# shipped at /usr/mpi/gcc/openmpi-4.1.9a1/).  Mirrors the openmpi.spec
+# mofed_prefix=1 behaviour on the .deb path.
+#
+# Why the prefix change is required: OMPI 5.x bundles openpmix and prrte
+# and, with the upstream default --prefix=/usr, drops libpmix.so.2 and
+# libprrte.so.3 into /usr/lib64/ plus help texts under /usr/share/{pmix,
+# prte}/.  Those collide with the system pmix / prrte-libs packages on
+# RHEL 10 / ctyunos / SLES (SW#5008199, SW#5010922).  Moving --prefix to
+# /usr/mpi/gcc/openmpi-<ver>/ keeps the bundled libs in a versioned
+# subdir and removes the collision.
+#
+# The Ubuntu 24.04 libevent-dev / evdns.h collision (SW#5009387) is
+# fixed by --with-libevent=external below (no bundled libevent ever
+# ships, regardless of --prefix), and is independent of MOFED_PREFIX.
+PKG_VERSION_UPSTREAM := $(shell dpkg-parsechangelog --show-field Version | sed -e 's/-[^-]*$$//')
+MOFED_PREFIX := /usr/mpi/gcc/openmpi-$(PKG_VERSION_UPSTREAM)
+
 %:
 	dh $@ --parallel
 
 override_dh_auto_clean:
 
 override_dh_auto_configure:
-	dh_auto_configure -- $(CONFIG_ARGS)
+	dh_auto_configure -- \
+		--with-libevent=external --with-hwloc=external \
+		--with-pmix=internal --with-prrte=internal \
+		--prefix=$(MOFED_PREFIX) \
+		--libdir=$(MOFED_PREFIX)/lib \
+		--sysconfdir=$(MOFED_PREFIX)/etc \
+		--includedir=$(MOFED_PREFIX)/include \
+		--datadir=$(MOFED_PREFIX)/share \
+		--mandir=$(MOFED_PREFIX)/share/man \
+		$(CONFIG_ARGS)
 
 override_dh_auto_test:
 


### PR DESCRIPTION
## Summary

Restore the long-standing MLNX_OFED / DOCA packaging convention of installing
OpenMPI under `/usr/mpi/gcc/openmpi-<version>/` for both RPM and DEB paths.
DOCA 3.3.0's `openmpi-4.1.9a1` already shipped at
`/usr/mpi/gcc/openmpi-4.1.9a1/`; OMPI 5.x dropped that and went with a bare
`--prefix=/usr` which causes file collisions with the system `pmix`,
`prrte-libs` and `libevent-dev` packages on RHEL/SLES/ctyunos/Ubuntu.

Fixes three P1 bugs in DOCA-Host 3.4.0-058000:

- [SW#5008199](https://redmine.mellanox.com/issues/5008199) — RHEL 10 ARM:
  `yum install doca-all` fails Transaction-test with ~95 file conflicts on
  `/usr/lib64/libpmix.so.2`, `/usr/lib64/libprrte.so.3`,
  `/usr/share/{pmix,prte}/*`, `/usr/bin/{prte,prted,prun,pterm,prte_info}`
  vs system `pmix-4.2.8-8.el10` / `prrte-libs-3.0.2-9.el10` /
  `prrte-3.0.2-9.el10`.
- [SW#5009387](https://redmine.mellanox.com/issues/5009387) — Ubuntu 24.04:
  `apt install` fails with
  `dpkg: trying to overwrite '/usr/include/evdns.h', which is also in package libevent-dev 2.1.12-stable-9ubuntu2`.
- [SW#5010922](https://redmine.mellanox.com/issues/5010922) — DOCA 3.3.0 →
  3.4.0 upgrade fails on the same Transaction-test conflicts (this is the
  upgrade-time manifestation of [SW#5008199](https://redmine.mellanox.com/issues/5008199)
  / [SW#5009387](https://redmine.mellanox.com/issues/5009387)).

## Root cause

OMPI 5.x bundles openpmix v5.0.10 and prrte v3.0.13 as 3rd-party submodules.
With `--prefix=/usr`, the bundled trees install straight into system locations
already owned by:

- RHEL/SLES `pmix` package → `/usr/lib64/libpmix.so.2`, `/usr/lib64/pmix/*`,
  `/usr/share/pmix/*`, `/usr/share/man/man{1,5}/{pmix_*,openpmix}.*`
- RHEL/SLES `prrte-libs` package → `/usr/lib64/libprrte.so.3`,
  `/usr/share/prte/*`
- RHEL/SLES `prrte` package → `/usr/bin/{prte,prted,prun,pterm,prte_info}`,
  `/usr/share/man/man*/prte*.gz`
- Ubuntu/Debian `libevent-dev` → `/usr/include/evdns.h`,
  `/usr/include/event2/*.h`

DOCA's openmpi rebuild pipeline
(`gitlab-master.nvidia.com/nbu-sw-build/packages/openmpi/.build.yaml`,
`doca-3.4.0` branch) explicitly forces
`--define 'all_external_3rd_party 0'` because pmix-devel and prrte-devel
are not packaged in most of the 60+ DOCA RPM target distros, so configure
falls back to bundled openpmix/prrte. Bundling is the right policy for that
build environment; the install location was the bug.

DOCA 3.3.0 didn't hit this because `openmpi-4.1.9a1` shipped at
`/usr/mpi/gcc/openmpi-4.1.9a1/` (versioned subdir, uniquely owned by the
openmpi package, structurally unable to collide with anything system).

## Fix

**Commit 1 — `contrib/dist/linux/openmpi.spec`:**

- Add a new `mofed_prefix` macro (default 1, guarded with `%{!?…}` so it
  remains overridable) that, when set without `install_in_opt`, points
  `_prefix`, `_libdir`, `_sysconfdir`, `_includedir`, `_mandir`,
  `_pkgdatadir`, `_defaultdocdir`, and `modulefile_path` at
  `/usr/mpi/gcc/%{name}-%{version}/`.
- Flip `install_shell_scripts` default from 0 → 1 (also guarded), so the spec
  auto-generates `${prefix}/bin/mpivars.{sh,csh}` for users to source
  (binaries are no longer on `$PATH` by default once the prefix moves out
  of `/usr`).
- `install_in_opt` is left untouched and takes priority if also set.

**Commit 2 — `contrib/dist/mofed/debian/{control.in,rules.in}`:**

- `control.in`: add `Build-Depends: debhelper (>= 8), libevent-dev,
  libhwloc-dev` so DOCA's `mk-build-deps --install` step pulls them
  into the build chroot.
- `rules.in`: derive
  `MOFED_PREFIX := /usr/mpi/gcc/openmpi-$(PKG_VERSION_UPSTREAM)` from
  `dpkg-parsechangelog` and extend `override_dh_auto_configure` to pass
  `--with-libevent=external --with-hwloc=external --with-pmix=internal
  --with-prrte=internal --prefix=$(MOFED_PREFIX) --libdir=… --sysconfdir=…
  --includedir=… --datadir=… --mandir=…`.

## Verification

End-to-end on `swx-clx01` against DOCA's actual `.build.yaml` build
pipeline (`rpmbuild -ba --define 'all_external_3rd_party 0' --define
'__brp_mangle_shebangs /usr/bin/true' QA_RPATHS=$((0x0001|0x0002)) *.spec`
for RPM; cp-debian + mk-build-deps + dpkg-buildpackage for DEB), using
the production tarball
`/auto/mswg/release/mlnx_ofed_ompi/openmpi-5.0.10rc2.2604281504-1.e7c33cff96.tar.gz`
(the exact tarball that shipped in DOCA 3.4.0-058000):

- **RPM** in `harbor.mellanox.com/hpcx/x86_64/rhel10.0/base:latest` with
  system `pmix-4.2.8-8.el10` + `prrte-3.0.2-9.el10` +
  `prrte-libs-3.0.2-9.el10` already installed → 3287 files in the patched
  RPM, all under `/usr/mpi/gcc/openmpi-5.0.10rc2.2604281504/` except
  auto-generated `/usr/lib/.build-id/<hash>/<hex>` debuginfo symlinks;
  `yum install` and `yum upgrade` (from baseline `openmpi-4.1.9a1` at
  `/usr/mpi/gcc/openmpi-4.1.9a1/`) both pass Transaction-test cleanly.
- **DEB** in `harbor.mellanox.com/hpcx/x86_64/ubuntu24.04/base:latest`
  with `libevent-dev 2.1.12-stable-9ubuntu2` and
  `libhwloc-dev 2.10.0-1build1` installed → 4015 entries, 3519 of them
  under `./usr/mpi/gcc/openmpi-5.0.10rc2/`, only 6 outside the prefix
  (debian-policy doc paths); `apt install` is clean;
  `/usr/include/evdns.h` stays owned only by `libevent-dev`.
- **Smoke**: `source /usr/mpi/gcc/openmpi-<version>/bin/mpivars.sh` on
  both distros, then `ompi_info --version` reports `Open MPI v5.0.10rc2`
  and a 2-rank hello-world MPI program runs successfully.

Reproducer scripts and produced packages are preserved in the
`hpcx-bug-rhel10` and `hpcx-bug-ubuntu2404` containers on `swx-clx01`
under `/scrap/artemry/hpcx-bug-repro/` for re-verification.

## Test plan

- [x] `Mellanox/ompi:v5.0.x_hpcx_mofed_prefix` builds clean on RHEL 10
      x86_64 via DOCA `.build.yaml` rpmbuild flags
- [x] Resulting RPM installs cleanly with system pmix/prrte/prrte-libs
      already present; `Transaction test succeeded`
- [x] Resulting RPM upgrades cleanly from `openmpi-4.1.9a1` baseline
- [x] `Mellanox/ompi:v5.0.x_hpcx_mofed_prefix` builds clean on Ubuntu
      24.04 x86_64 via DOCA `.build.yaml` deb pipeline
- [x] Resulting DEB installs cleanly with `libevent-dev` already present
- [x] `mpirun` + `ompi_info --version` work after sourcing `mpivars.sh`
- [x] 2-rank hello-world MPI program runs successfully on both distros
- [ ] Once merged, bump `hpcx_ompi5_branch` SHA in
      `release_config/hpcx-config.txt` of `Mellanox/hpcx` (separate small PR)
- [ ] DOCA-Host respin (058001+) consumes the new tarball

## Related

- Mellanox/hpcx#272 — Arnaud's stopgap libevent-only fix on the
  hpcx-pointer side (sed-injected in `pointers/functions.sh`). Targets
  [SW#5009387](https://redmine.mellanox.com/issues/5009387) only (DEB).
  Should land first to unblock DOCA respin ASAP. Once this PR merges and
  `hpcx_ompi5_branch` is bumped, the libevent .deb sed-injection in
  Mellanox/hpcx#272 becomes a guaranteed no-op via its own `grep -q`
  guards and can be reverted in a follow-up tidy-up PR; the Sphinx
  PATH commit `Mellanox/hpcx@3116528` is orthogonal and stays.
- Redmine: [SW#5008199](https://redmine.mellanox.com/issues/5008199),
  [SW#5009387](https://redmine.mellanox.com/issues/5009387),
  [SW#5010922](https://redmine.mellanox.com/issues/5010922) — all three
  updated with cross-references and reproduction details.