### PR TITLE
contrib/patches/prrte: fix -x VAR=value env propagation to local procs

### DIFF
--- a/contrib/patches/prrte/0003-prte-app-parse-fwd-envar-assignment-into-app-env.patch
+++ b/contrib/patches/prrte/0003-prte-app-parse-fwd-envar-assignment-into-app-env.patch
@@ -1,0 +1,14 @@
+diff --git a/src/prted/prte_app_parse.c b/src/prted/prte_app_parse.c
+index f3724841fc..a1b2c3d4ef 100644
+--- a/src/prted/prte_app_parse.c
++++ b/src/prted/prte_app_parse.c
+@@ -377,6 +377,11 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
+                 envt.value = strdup(value);
+                 PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
++                /* Also set directly in app->app.env so local processes on the
++                 * submission host see the value. Must come before
++                 * PMIX_ENVAR_DESTRUCT which frees param (envt.envar) and
++                 * envt.value, leaving both as dangling pointers. */
++                PMIX_SETENV_COMPAT(param, value, true, &app->app.env);
+                 PMIX_ENVAR_DESTRUCT(&envt);
+             } else {


### PR DESCRIPTION
When mpirun uses '-x VAR=value', the FWD_ENVAR handler stores the value as PMIX_SET_ENVAR in app->info but not in app->app.env. Remote processes receive the correct environment via PRTE_JOB_SET_ENVAR, but local processes on the submission host miss it due to a sequencing issue where PRTE_JOB_SET_ENVAR is not yet committed to jdata->attributes when the local ODLS launches them.

Fix: call PMIX_SETENV_COMPAT(param, value, ..., &app->app.env) before PMIX_ENVAR_DESTRUCT, which frees param (envt.envar) and envt.value and would leave both as dangling pointers.

