### PR TITLE
packaging(deb+rpm): expose OMPI wrappers under /usr/bin via update-alternatives (SW#5150809)

### DIFF
--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -740,6 +740,130 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 #############################################################################
 #
+# Post Install / Post Uninstall Section (update-alternatives,
+# all-in-one rpm)
+#
+# All-in-one twin of the update-alternatives hook below (SW#5150809).
+# build_all_in_one_rpm defaults to 1 in this spec, so the single-rpm
+# path is what a default rpmbuild invocation takes -- without this arm
+# the wrappers would stay off $PATH exactly there, and only the
+# sub-package (%post runtime) variant would carry the fix.  Same
+# alternatives group, same priority 50, same defensive guards as that
+# hook and as the .deb postinst.
+#
+# Deliberately a self-contained additive block rather than a merge into
+# the upstream mpi_selector %post above: the fork's delta against the
+# upstream openmpi.spec stays pure-insertion and survives v5.0.x
+# rebases without conflicts.  The !use_mpi_selector guard makes the two
+# %post declarations mutually exclusive by construction (no
+# duplicate-%post rpmbuild error); when mpi_selector is enabled,
+# wrapper exposure is that mechanism's job anyway.
+#############################################################################
+%if !%{use_mpi_selector}
+%if %{build_all_in_one_rpm}
+%if %(test "%{_prefix}" = "/usr" && echo 0 || echo 1)
+%post
+# update-alternatives lives at /usr/sbin/ on RHEL/Rocky (chkconfig), at
+# /usr/bin/ on SUSE; scriptlet PATH is not guaranteed, so resolve and
+# invoke the absolute path.
+UA=/usr/sbin/update-alternatives
+[ -x "$UA" ] || UA=/usr/bin/update-alternatives
+if [ "$1" -ge 1 ] && [ -x "$UA" ] && [ -x %{_prefix}/bin/mpicc ]; then
+    "$UA" \
+        --install /usr/bin/mpicc      mpicc      %{_prefix}/bin/mpicc      50 \
+        --slave   /usr/bin/mpicxx     mpicxx     %{_prefix}/bin/mpicxx        \
+        --slave   /usr/bin/mpic++     mpic++     %{_prefix}/bin/mpic++        \
+        --slave   /usr/bin/mpif77     mpif77     %{_prefix}/bin/mpif77        \
+        --slave   /usr/bin/mpif90     mpif90     %{_prefix}/bin/mpif90        \
+        --slave   /usr/bin/mpifort    mpifort    %{_prefix}/bin/mpifort       \
+        --slave   /usr/bin/mpirun     mpirun     %{_prefix}/bin/mpirun        \
+        --slave   /usr/bin/mpiexec    mpiexec    %{_prefix}/bin/mpiexec       \
+        --slave   /usr/bin/ompi_info  ompi_info  %{_prefix}/bin/ompi_info     \
+        || :
+fi
+exit 0
+
+%postun
+# Drop the alternatives group on final removal only ("$1" -eq 0), same
+# semantics as the %postun runtime variant below and the .deb prerm.
+UA=/usr/sbin/update-alternatives
+[ -x "$UA" ] || UA=/usr/bin/update-alternatives
+if [ "$1" -eq 0 ] && [ -x "$UA" ]; then
+    "$UA" --remove mpicc %{_prefix}/bin/mpicc 2>/dev/null || true
+fi
+exit 0
+%endif
+%endif
+%endif
+
+#############################################################################
+#
+# Post Install / Pre Uninstall Section (update-alternatives)
+#
+# When the OMPI wrappers do not live under /usr/bin/ (i.e. mofed_prefix=1
+# or install_in_opt=1), register them via update-alternatives so that
+# downstream consumers that resolve `mpicc` via $PATH (meson's
+# find_program(), AC_PATH_PROG, plain `mpicc` invocations in CI scripts)
+# keep working without having to source mpivars.sh first.  Mirrors the
+# Debian-side dpkg update-alternatives hook (SW#5030263 reproduces on
+# the Rocky 9.2 bfb the same way it does on the Ubuntu 24.04 / Debian 12
+# bfbs -- this RPM hook is the symmetric fix).
+#
+# Priority 50 matches Debian stock openmpi-bin and the DEB side of this
+# packaging, keeping behaviour predictable when multiple openmpi
+# implementations co-exist.  Only the wrapper binaries are exposed under
+# /usr/bin/; libpmix.so.2 / libprrte.so.3 / bundled libevent stay under
+# the versioned prefix, so SW#5008199 / SW#5009387 / SW#5010922 remain
+# closed.
+#
+# Skip the registration when --prefix=/usr (mofed_prefix=0 +
+# install_in_opt=0), since the wrappers already live in /usr/bin/ and an
+# alternatives entry would point a symlink at itself.  The
+# build_all_in_one_rpm path is covered by the self-contained
+# %post/%postun pair above (SW#5150809), kept separate so the fork's
+# delta against the upstream spec stays pure-insertion.
+#############################################################################
+%if !%{build_all_in_one_rpm}
+%if %(test "%{_prefix}" = "/usr" && echo 0 || echo 1)
+# Defensive guards:
+#   * Two possible binary paths -- update-alternatives ships at
+#     /usr/sbin/update-alternatives on RHEL/Rocky/AlmaLinux (chkconfig
+#     package), at /usr/bin/update-alternatives on SUSE/SLES (the
+#     update-alternatives package), and is missing on some minimal /
+#     UBI / distroless images.  Either path is invoked via PATH so we
+#     don't hardcode one.
+#   * `exit 0` at the end keeps the scriptlet rc=0 even if a slave
+#     entry fails (e.g. mpif77 not shipped in a particular build
+#     config), so RPM does not warn `scriptlet failed` and CI that
+#     reads the rc does not flag the install.
+%post runtime
+if [ "$1" -ge 1 ] && [ -x %{_prefix}/bin/mpicc ]; then
+    if [ -x /usr/sbin/update-alternatives ] || [ -x /usr/bin/update-alternatives ]; then
+        update-alternatives \
+            --install /usr/bin/mpicc      mpicc      %{_prefix}/bin/mpicc      50 \
+            --slave   /usr/bin/mpicxx     mpicxx     %{_prefix}/bin/mpicxx        \
+            --slave   /usr/bin/mpic++     mpic++     %{_prefix}/bin/mpic++        \
+            --slave   /usr/bin/mpif77     mpif77     %{_prefix}/bin/mpif77        \
+            --slave   /usr/bin/mpif90     mpif90     %{_prefix}/bin/mpif90        \
+            --slave   /usr/bin/mpifort    mpifort    %{_prefix}/bin/mpifort       \
+            --slave   /usr/bin/mpirun     mpirun     %{_prefix}/bin/mpirun        \
+            --slave   /usr/bin/mpiexec    mpiexec    %{_prefix}/bin/mpiexec       \
+            --slave   /usr/bin/ompi_info  ompi_info  %{_prefix}/bin/ompi_info     \
+            || :
+    fi
+fi
+exit 0
+
+%postun runtime
+if [ "$1" -eq 0 ] && command -v update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove mpicc %{_prefix}/bin/mpicc 2>/dev/null || true
+fi
+exit 0
+%endif
+%endif
+
+#############################################################################
+#
 # Files Section
 #
 #############################################################################

--- a/contrib/dist/mofed/debian/openmpi.postinst.in
+++ b/contrib/dist/mofed/debian/openmpi.postinst.in
@@ -1,0 +1,54 @@
+#!/bin/sh
+# postinst for the MLNX_OFED / DOCA openmpi .deb.
+#
+# The package installs everything under /usr/mpi/gcc/openmpi-<ver>/
+# (see rules.in MOFED_PREFIX) so that the bundled openpmix/prrte do not
+# collide with the system pmix/prrte-libs packages on RHEL10/SLES/ctyunos
+# (SW#5008199, SW#5010922) and so that the bundled libevent does not
+# collide with libevent-dev on Ubuntu 24.04 (SW#5009387).
+#
+# Side effect of that prefix move: the OMPI compiler wrappers and
+# launchers (mpicc, mpirun, ...) are no longer on $PATH, breaking
+# downstream consumers that resolve them via find_program('mpicc') /
+# AC_PATH_PROG / a plain `mpicc` invocation in CI -- e.g. the bfb
+# time_sync/dpu meson build (SW#5030263).
+#
+# Restore those binaries under /usr/bin/ via update-alternatives so
+# every consumer (current and future) gets them on $PATH without having
+# to know the versioned prefix.  Only the wrapper binaries are exposed
+# this way -- libpmix.so.2 / libprrte.so.3 / bundled libevent stay under
+# the versioned prefix, so SW#5008199 / SW#5009387 / SW#5010922 remain
+# closed.
+#
+# Priority 50 matches the Debian stock openmpi-bin alternative priority,
+# so an admin who installs both packages on the same host keeps a
+# predictable default and can switch via `update-alternatives --config
+# mpi` if needed.
+
+set -e
+
+MOFED_PREFIX="@MOFED_PREFIX@"
+
+case "$1" in
+    configure)
+        if [ -x "$MOFED_PREFIX/bin/mpicc" ]; then
+            update-alternatives \
+                --install /usr/bin/mpicc      mpicc      "$MOFED_PREFIX/bin/mpicc"      50 \
+                --slave   /usr/bin/mpicxx     mpicxx     "$MOFED_PREFIX/bin/mpicxx"        \
+                --slave   /usr/bin/mpic++     mpic++     "$MOFED_PREFIX/bin/mpic++"        \
+                --slave   /usr/bin/mpif77     mpif77     "$MOFED_PREFIX/bin/mpif77"        \
+                --slave   /usr/bin/mpif90     mpif90     "$MOFED_PREFIX/bin/mpif90"        \
+                --slave   /usr/bin/mpifort    mpifort    "$MOFED_PREFIX/bin/mpifort"       \
+                --slave   /usr/bin/mpirun     mpirun     "$MOFED_PREFIX/bin/mpirun"        \
+                --slave   /usr/bin/mpiexec    mpiexec    "$MOFED_PREFIX/bin/mpiexec"       \
+                --slave   /usr/bin/ompi_info  ompi_info  "$MOFED_PREFIX/bin/ompi_info"
+        fi
+        ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/dist/mofed/debian/openmpi.prerm.in
+++ b/contrib/dist/mofed/debian/openmpi.prerm.in
@@ -1,0 +1,22 @@
+#!/bin/sh
+# prerm for the MLNX_OFED / DOCA openmpi .deb.  See openmpi.postinst.in
+# for the rationale behind the update-alternatives entry.
+
+set -e
+
+MOFED_PREFIX="@MOFED_PREFIX@"
+
+case "$1" in
+    remove)
+        if [ -x "$MOFED_PREFIX/bin/mpicc" ]; then
+            update-alternatives --remove mpicc "$MOFED_PREFIX/bin/mpicc"
+        fi
+        ;;
+
+    upgrade|deconfigure|failed-upgrade)
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/dist/mofed/debian/rules.in
+++ b/contrib/dist/mofed/debian/rules.in
@@ -43,3 +43,23 @@ override_dh_auto_configure:
 
 override_dh_auto_test:
 
+# Expose the OMPI compiler wrappers and launchers under /usr/bin/ via
+# update-alternatives so consumers that look up `mpicc` on $PATH keep
+# working after the prefix move to /usr/mpi/gcc/openmpi-<ver>/.  See
+# debian/openmpi.postinst.in for the rationale (SW#5030263).
+#
+# The maintainer scripts are templated -- @MOFED_PREFIX@ is substituted
+# with the same value used for --prefix above, so the postinst points at
+# exactly the binaries this build just installed.
+override_dh_installdeb:
+	sed -e 's|@MOFED_PREFIX@|$(MOFED_PREFIX)|g' \
+		debian/openmpi.postinst.in > debian/openmpi.postinst
+	sed -e 's|@MOFED_PREFIX@|$(MOFED_PREFIX)|g' \
+		debian/openmpi.prerm.in > debian/openmpi.prerm
+	chmod 755 debian/openmpi.postinst debian/openmpi.prerm
+	dh_installdeb
+
+override_dh_clean:
+	rm -f debian/openmpi.postinst debian/openmpi.prerm
+	dh_clean
+


### PR DESCRIPTION
> **Revived 13 Jul 2026 for SW#5150809** (HPC-X 2.51 / Rel2A-Jul26). This implements the 14-May decision taken on SW#5030263 — *"for July we will create a predefined symbolic link that will point to the right place where mpicc is installed"* — and the new ticket's explicit requirement that the fix apply on **all** supported DPU operating systems, not just Ubuntu. Despite the original `debian/mofed:` title, this PR already covers **both** packaging paths: the MOFED/DOCA **.deb** (postinst/prerm via dpkg `update-alternatives`) and the **.rpm** (`%post runtime` / `%postun runtime` alternatives block in `contrib/dist/linux/openmpi.spec`), so Ubuntu/Debian and RHEL/Rocky bfbs are all addressed.

## Summary

- Restore the OMPI compiler wrappers (`mpicc`, `mpicxx`, `mpic++`, `mpif77`, `mpif90`, `mpifort`, `mpirun`, `mpiexec`, `ompi_info`) under `/usr/bin/` via `update-alternatives`, so downstream consumers that resolve `mpicc` from `$PATH` keep working after the MOFED prefix move done in #35.
- Priority 50 matches Debian stock `openmpi-bin` so behaviour stays predictable when both packages co-exist.
- Only the wrapper binaries are exposed under `/usr/bin/`; `libpmix.so.2` / `libprrte.so.3` / bundled libevent stay in the versioned subdir, so **SW#5008199 / SW#5009387 / SW#5010922 remain closed**.

## Why

#35 (mofed_prefix) intentionally moved the install to `/usr/mpi/gcc/openmpi-<ver>/` to fix three system-pmix / system-prrte / system-libevent collision tickets on RHEL 10 / SLES / ctyunos / Ubuntu 24.04.

Side effect on the bfb `time_sync/dpu` meson build (SW#5030263, now SW#5150809) — meson does `find_program('mpicc')` against `$PATH` and now fails:

```
Program mpicc found: NO
time_sync/dpu/meson.build:29: WARNING: Skipping compilation of time_sync - missing mpicc
```

Reverting the prefix move would reopen SW#5008199 / SW#5009387 / SW#5010922. Patching every downstream consumer to know the versioned prefix is impractical. `update-alternatives` puts the wrappers back on `$PATH` while keeping the prefix move intact — the same convention Debian stock `openmpi-bin` already uses.

## How

- **deb**: new `contrib/dist/mofed/debian/openmpi.postinst.in` and `openmpi.prerm.in` with a single `@MOFED_PREFIX@` token; `rules.in` sed-substitutes the token at build time, using the same `MOFED_PREFIX` already computed from `dpkg-parsechangelog` for `--prefix=`. Single source of truth, no drift between the configure prefix and the postinst paths. `override_dh_clean` removes the generated files so the working tree stays clean.
- **rpm**: `%post runtime` / `%postun runtime` in `contrib/dist/linux/openmpi.spec` registers/removes the same alternatives group. Guarded to be a no-op when the wrappers already live in `/usr/bin` (`--prefix=/usr`), on the `build_all_in_one_rpm` path, and on images that ship no `update-alternatives` binary.

Closes SW#5150809.
Refs SW#5030263 (rejected on 14 May — fix deliberately deferred to the July release), SW#5008199, SW#5009387, SW#5010922, #35.

### Notes for reviewers

- **Why `update-alternatives` rather than a plain packaged symlink**: this same package also installs on doca-host x86 servers, where a distro MPI (`openmpi-bin`, mpich) may already own `/usr/bin/mpicc`. A payload symlink would hard-fail the install with a file conflict; alternatives coexists (priority 50, admin-overridable via `--config`). Should this package ever become bfb-only, the scriptlets can be simplified into packaged links.
- **Upstream candidacy**: the rpm all-in-one hook is deliberately a self-contained, pure-insertion block that is inert at the default `/usr` prefix — a candidate for upstreaming to open-mpi/ompi, where the same `$PATH` gap exists with `install_in_opt=1`. To be proposed separately; the fork-side block gets dropped once an upstream tag carries it.
