### PR TITLE
openmpi.spec: obsolete older openmpi RPMs on upgrade (SW#5031064)

### DIFF
--- a/contrib/dist/linux/openmpi.spec
+++ b/contrib/dist/linux/openmpi.spec
@@ -303,6 +303,16 @@ Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: %{_prefix}
 Provides: mpi
 Provides: openmpi = %{version}
+# Force removal of any older openmpi RPM during upgrade transactions.
+# Without this, a host that holds an older openmpi (e.g. DOCA 2.9.4's
+# openmpi-3:4.1.7rc1-1.2410325 with Requires: libhcoll.so.1) blocks
+# `yum/zypper update doca-ofed` when the new DOCA repo no longer ships
+# the hcoll RPM that provided libhcoll.so.1 (SW#5031064).  The mofed
+# prefix added in #35 isolates new files in /usr/mpi/gcc/openmpi-<ver>/
+# so the old and new packages do not overwrite each other, but only
+# Obsoletes: tells the depsolver that the old payload (and its dangling
+# libhcoll.so.1 Requires) must go away in the same transaction.
+Obsoletes: openmpi < %{epoch}:%{version}-%{release}
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
 %if %{disable_auto_requires}
 AutoReq: no
@@ -350,6 +360,12 @@ Group: Development/Libraries
 Provides: mpi
 Provides: openmpi = %{version}
 Provides: openmpi-runtime = %{version}
+# See the Obsoletes: note on the main package above (SW#5031064).
+# The runtime sub-package also Provides: openmpi, so it must obsolete
+# the older openmpi RPM too -- otherwise zypper would still see the
+# pre-split openmpi-3:4.1.7rc1 as installed and dangling on libhcoll.so.1.
+Obsoletes: openmpi < %{epoch}:%{version}-%{release}
+Obsoletes: openmpi-runtime < %{epoch}:%{version}-%{release}
 %if %{disable_auto_requires}
 AutoReq: no
 %endif
@@ -394,6 +410,7 @@ Group: Development/Libraries
 AutoReq: no
 %endif
 Provides: openmpi-devel = %{version}
+Obsoletes: openmpi-devel < %{epoch}:%{version}-%{release}
 Requires: %{name}-runtime
 
 %description devel
@@ -425,6 +442,7 @@ Group: Development/Documentation
 AutoReq: no
 %endif
 Provides: openmpi-docs = %{version}
+Obsoletes: openmpi-docs < %{epoch}:%{version}-%{release}
 Requires: %{name}-runtime
 
 %description docs


### PR DESCRIPTION
## Summary

- Add `Obsoletes:` clauses to `contrib/dist/linux/openmpi.spec` so the RPM depsolver removes any older `openmpi` (including the split sub-packages `openmpi-runtime` / `openmpi-devel` / `openmpi-docs`) in the same transaction that installs this build.
- Fixes the SLES 15.4 / zypper upgrade hang from DOCA 2.9.4 → 3.4.0 (SW#5031064).
- DEB packaging path intentionally untouched — `dpkg` handles same-`Package:` upgrades natively and the bug does not manifest there.

## Why

The mofed prefix from #35 installs the new `openmpi` payload under `/usr/mpi/gcc/openmpi-<ver>/`, which sidesteps file-conflict errors but leaves the older `openmpi` RPM on disk. On SLES 15.4 the older one (DOCA 2.9.4: `openmpi-3:4.1.7rc1-1.2410325`) keeps a hard `Requires: libhcoll.so.1`. DOCA 3.4.0 retired the standalone `hcoll` RPM (hcoll is now only bundled inside the HPC-X tarball as the `coll-hcoll` MCA plugin and is no longer a declared RPM dependency — see `35db01e36f`), so zypper plans to delete `hcoll-4.8.3230-1.2410068` and the resulting state breaks:

```
Problem: the installed openmpi-3:4.1.7rc1-1.2410325.x86_64 requires
'libhcoll.so.1()(64bit)', but this requirement cannot be provided
  deleted providers: hcoll-4.8.3230-1.2410068.x86_64
 Solution 1: deinstallation of openmpi-3:4.1.7rc1-1.2410325.x86_64
 Solution 2: do not install doca-ofed-3.4.0-075000.x86_64
 Solution 3: break openmpi-3:4.1.7rc1-1.2410325.x86_64 by ignoring some of its dependencies
```

Solutions 1/2/3 all require manual operator action. With `Obsoletes:` on the new openmpi, the depsolver picks solution 1 automatically: the older openmpi is marked for removal in the same transaction, its dangling `Requires: libhcoll.so.1` disappears with it, and `yum/zypper update doca-ofed` completes.

## How

5 `Obsoletes:` clauses, one per package block, all of the form `Obsoletes: <self> < %{epoch}:%{version}-%{release}`:

| Block | Obsoletes |
|---|---|
| main (`Name: openmpi`) | `openmpi` |
| `%package runtime` (also `Provides: openmpi`) | `openmpi`, `openmpi-runtime` |
| `%package devel` | `openmpi-devel` |
| `%package docs` | `openmpi-docs` |

The strict `<` comparison and the use of the live `%{epoch}:%{version}-%{release}` macros prevent self-obsolete loops: a build with the same EVR as itself never satisfies `openmpi < <self>`.

Closes SW#5031064.
Refs SW#5008199, SW#5009387, SW#5010922, #35.
