### PR TITLE
[HPCINFRA-4211] docs: gate Python doc dependencies on Python version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,25 @@
-sphinx>=4.2.0
+# Open MPI documentation build dependencies.
+#
+# HPCINFRA-4211: the build matrix spans Python 3.6 (RHEL8, SLES15, RHEL7)
+# through Python 3.13 (Debian 13). No single Sphinx release covers that whole
+# range -- Sphinx 6+ needs Python >= 3.8, 7.2+ needs >= 3.9, 8+ needs >= 3.10 --
+# so an unbounded "sphinx>=4.2.0" lets pip (invoked with --upgrade) install a
+# Sphinx too new for the older interpreters, and the docs build fails on
+# Python 3.6-3.8. Conversely, hard-pinning to a single old release breaks the
+# newest interpreters (Debian 13 / Python 3.13). Use PEP 508 environment
+# markers so pip selects a compatible set per Python -- the same mechanism
+# upstream Open MPI already uses for its Python 3.6 backports.
+
+# Modern Python (>= 3.9): current Sphinx, unchanged from the upstream default.
+sphinx>=4.2.0 ; python_version >= "3.9"
+sphinx-rtd-theme ; python_version >= "3.9"
+docutils ; python_version >= "3.9"
+
+# Legacy Python (3.6-3.8): last Sphinx line that still runs on these
+# interpreters (Sphinx 5.x); docutils/sphinx-rtd-theme capped to match.
+sphinx>=4.2.0,<6 ; python_version < "3.9"
+sphinx-rtd-theme<2.0.0 ; python_version < "3.9"
+docutils<0.20 ; python_version < "3.9"
+
+# recommonmark has no Python-version-sensitive cap.
 recommonmark
-docutils
-sphinx-rtd-theme


### PR DESCRIPTION
## HPCINFRA-4211 — Python-version-aware doc dependencies

**Draft for code review.** Supersedes the hard-pin approach of #19 (and #18 on `v4.1.x_hpcx`).

### Problem
`docs/requirements.txt` declares `sphinx>=4.2.0` with no upper bound, and the HPC-X build installs it with `pip install --upgrade -r docs/requirements.txt` (`hpc-stack-init.sh`). The build matrix runs Python **3.6** (RHEL8, SLES15, RHEL7) up to **3.13** (Debian 13):

| Sphinx | min Python |
|---|---|
| 5.x | 3.6 |
| 6.x / 7.0–7.1 | 3.8 |
| 7.2+ | 3.9 |
| 8.x | 3.10+ |

- Unbounded + `--upgrade` → pip installs Sphinx 7.x/8.x → **fails on Python 3.6–3.8**.
- Hard-pinning `sphinx==5.3.0` (the earlier drafts) → **fails on Python 3.13** (Sphinx 5.3.0 / docutils 0.18.1 use stdlib modules removed in 3.12/3.13).

No single version satisfies the whole matrix.

### Fix
PEP 508 environment markers, so pip picks a compatible set per interpreter — the same mechanism upstream Open MPI already uses for its Python 3.6 backports:

- **Python ≥ 3.9**: unchanged (current unbounded line) → Debian 13 / Ubuntu 24 stay green.
- **Python 3.6–3.8**: capped to the last Sphinx that runs there (`< 6`), with matching `docutils`/`sphinx-rtd-theme` caps.

Robust against the `--upgrade` flag, because pip evaluates the markers before resolution.

### Validation still to run (before undraft)
- [ ] Build docs on **rhel8, sles15** (Python 3.6) — was the original failure.
- [ ] Build docs on **debian13, ubuntu24.04** (Python 3.12/3.13) — was the hard-pin regression.
- [ ] Build docs on **rhel9, ubuntu22.04** (Python 3.9/3.10).
- [ ] Confirm each: pip resolves cleanly, `sphinx-build` exits 0, man pages generated.

### Follow-ups (not in this PR)
- Sibling change on **`v4.1.x_hpcx`** (same file, same fix).
- Align `3rd-party/openpmix/docs/requirements.txt` and `3rd-party/prrte/docs/requirements.txt` for ReadTheDocs consistency (not build-blocking: the build only pip-installs OMPI's list).
- After merge: bump the OMPI pin in `hpcx/release_config/hpcx-config.txt`.
