### PR TITLE
contrib/platform/mellanox: drop deprecated mpirun-prefix-by-default

### DIFF
--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -1,7 +1,11 @@
 enable_mca_no_build=btl-uct,coll-han,coll-adapt,part-persist
 enable_mca_dso=coll-cuda,accelerator-cuda,btl-smcuda,btl-uct,rcache-gpusm,rcache-rgpusm,coll-hcoll,coll-ucc,pml-ucx,osc-ucx
 enable_debug_symbols=yes
-enable_mpirun_prefix_by_default=yes
+# mpirun/orterun-prefix-by-default is deprecated in OMPI 5 and intentionally not
+# replaced by enable_prte_prefix_by_default here: platform variables are sourced
+# into the top-level configure and do not reach the PRRTE sub-configure, while
+# leaving the variable unset makes ompi_setup_prrte.m4 pass
+# --enable-prte-prefix-by-default to PRRTE on its own.
 with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes


### PR DESCRIPTION
Every HPC-X package build logs this in config_openmpi5.log:

```
configure: WARNING: Open MPI no longer uses the ORTE environment - it has been
configure: WARNING: replaced by PRRTE. Accordingly, the "--enable-orterun-prefix-by-default"
configure: WARNING: and "--enable-mpirun-prefix-by-default" options have been replaced
configure: WARNING: by "--enable-prte-prefix-by-default". We will do the translation for
configure: WARNING: you now, but these older options are deprecated and will be removed
configure: WARNING: in a later release, so please update your build scripts.
```

The warning comes from `enable_mpirun_prefix_by_default=yes` in `contrib/platform/mellanox/optimized` (hpc-stack-init.sh configures OMPI with `--with-platform=` that file).

This drops the line rather than renaming it to `enable_prte_prefix_by_default`. Renaming would silently turn prefix-by-default off: platform files are sourced into the top-level configure (`opal_load_platform.m4`) and never enter `ac_configure_args`, so the variable would not reach the PRRTE sub-configure, while `ompi_setup_prrte.m4` would see it set and skip the fallback that appends `--enable-prte-prefix-by-default` to the internal PRRTE args. With the line removed the fallback still fires and the PRRTE configure invocation stays identical to today's, just without the warning.

Today's builds already get the option only through that fallback. From `config_openmpi5.log` of the 2026-07-06 daily (ubuntu22.04), the PRRTE sub-configure invocation is:

```
running /bin/bash ./configure --disable-option-checking ... --disable-devel-check --enable-prte-prefix-by-default --with-libevent ... '--enable-mpi1-compatibility' '--without-xpmem' '--with-cuda=...' '--with-slurm' ...
```

i.e. the bare `--enable-prte-prefix-by-default` from the fallback, and only real command-line options in the forwarded args - nothing from the platform file. (The deprecated-option "translation" in `ompi_setup_prrte.m4` assigns from `$mpirun_prefix_by_default`, which nothing ever sets, so it contributes nothing either.)

For the same reason the warning can't be fixed from the hpcx side: passing `--enable-prte-prefix-by-default` on the configure command line while the platform file still sets the deprecated variable is rejected by `ompi_setup_prrte.m4` as a configure error.

Closes: [SW#4929805](https://redmine.mellanox.com/issues/4929805) / [HPCINFRA-4277](https://jirasw.nvidia.com/browse/HPCINFRA-4277)

---
Assignee: @orbalayla-nvidia. Review: @janjust @celermajer @dpressle - I can't set the formal assignee/reviewer fields on this repo (read access only), so tagging here;